### PR TITLE
Fixed: `output` is not always non-empty.

### DIFF
--- a/exec/renderer.go
+++ b/exec/renderer.go
@@ -61,8 +61,9 @@ func (r *Renderer) Visit(node nodes.Node) (nodes.Visitor, error) {
 		return nil, nil
 	case *nodes.Data:
 		output := n.Data.Val
-		if n.RemoveFirstLineReturn && (output[0:1] == "\n" || output[0:2] == "\r\n") {
-			output = output[1:]
+		if n.RemoveFirstLineReturn {
+			output = strings.TrimSuffix(output, "\n")
+			output = strings.TrimSuffix(output, "\r\n")
 		}
 		if n.Trim.Left {
 			output = strings.TrimLeft(output, " \r\n\t")


### PR DESCRIPTION
I have a template string like this: `{{ my_var }}`, and value of `my_var` is just one digit: `1`, so the render result is: `1`.
The change made in v2.3.2 causes panic in this case:
https://github.com/NikolaLohinski/gonja/commit/8d56e4ec3aefeb14cc235a9a36eeb7f97b731214#diff-2ccb40adee72b3c171e64e7f3353abf98eb3f49be349a10dd6b6b14109577fdfR64