### PR TITLE
Handle negative steps in range function

### DIFF
--- a/builtins/global_functions.go
+++ b/builtins/global_functions.go
@@ -34,10 +34,21 @@ func rangeFunction(_ *exec.Evaluator, params *exec.VarArgs) (<-chan int, error) 
 	default:
 		return nil, exec.ErrInvalidCall(errors.New("expected signature is [start, ]stop[, step] where all arguments are integers"))
 	}
+
+	if step == 0 {
+		return nil, exec.ErrInvalidCall(errors.New("step cannot be 0"))
+	}
+
 	channel := make(chan int)
 	go func() {
-		for i := start; i < stop; i += step {
-			channel <- i
+		if step > 0 {
+			for i := start; i < stop; i += step {
+				channel <- i
+			}
+		} else {
+			for i := start; i > stop; i += step {
+				channel <- i
+			}
 		}
 		close(channel)
 	}()

--- a/tests/integration/functions_test.go
+++ b/tests/integration/functions_test.go
@@ -68,6 +68,9 @@ var _ = Context("functions", func() {
 	})
 	Context("range", func() {
 		shouldRender(`{% for i in range(10) %}{{ i }}{% endfor %}`, "0123456789")
+		shouldRender(`{% for i in range(1, 10, 2) %}{{ i }}{% endfor %}`, "13579")
+		shouldRender(`{% for i in range(10, 1, -1) %}{{ i }}{% endfor %}`, "1098765432")
+		shouldRender(`{% for i in range(10, 1, -2) %}{{ i }}{% endfor %}`, "108642")
 		shouldFail("{% set invalid = range(True) -%}", "invalid call to function 'range': expected signature is \\[start, ]stop\\[, step] where all arguments are integers")
 	})
 })


### PR DESCRIPTION
This PR fixes #42. I noticed that step being zero is also not handled, whereas Jinja handles that, so I decided to add a check for that too.