### PR TITLE
feat(methods): add items() method to dict

### DIFF
--- a/builtins/methods/dict.go
+++ b/builtins/methods/dict.go
@@ -18,4 +18,14 @@ var dictMethods = NewMethodSet[map[string]interface{}](map[string]Method[map[str
 		sort.Strings(keys)
 		return keys, nil
 	},
+	"items": func(self map[string]interface{}, selfValue *Value, arguments *VarArgs) (interface{}, error) {
+		if err := arguments.Take(); err != nil {
+			return nil, ErrInvalidCall(err)
+		}
+		items := make([]interface{}, 0)
+		for _, item := range self {
+			items = append(items, item)
+		}
+		return items, nil
+	},
 })


### PR DESCRIPTION
Add the `items()` method to dictionaries. E.g: `{{ mydict.items() }}`

I've tested this with this code:

```go
package main

import (
	"fmt"
	"os"

	"github.com/nikolalohinski/gonja/v2"
	"github.com/nikolalohinski/gonja/v2/exec"
)

func main() {
	data := exec.NewContext(map[string]interface{}{
		"mydict": map[string]interface{}{
			"nested_dict": map[string]interface{}{
				"key": "val",
			},
			"mystr": "string",
			"myint": 1,
			"myslice": []string{"one", "two"},
		},
	})

	tpls := []string{
		"Dict: {{ mydict }}\n",
		"Items (works): {{ mydict.items() }}\n",
		"Items (extra arg): {{ mydict.items(1) }}\n",
		"Items (iter):{% for v in mydict.items() %} {{ v }}{% endfor %}\n",
	}

	for _, tpl := range tpls {
		fmt.Printf("TEMPLATE: %s", tpl)
		template, err := gonja.FromString(tpl)
		if err != nil {
			fmt.Printf("Error loading template %q: %v\n", err)
			continue
		}

		if err = template.Execute(os.Stdout, data); err != nil {
			fmt.Printf("Error executing template %q: %v\n", err)
		}
	}
}
```
Example output:
```
TEMPLATE: Dict: {{ mydict }}
Dict: {'myint': 1, 'myslice': ['one', 'two'], 'mystr': 'string', 'nested_dict': {'key': 'val'}}
TEMPLATE: Items (works): {{ mydict.items() }}
Items (works): [{'key': 'val'}, 1, ['one', 'two'], 'string']
TEMPLATE: Items (extra arg): {{ mydict.items(1) }}
Items (extra arg): Error executing template "unable to execute template: Unable to render expression at line 1: call([1], map[]): invalid call to method 'items' of {'myint': 1, 'myslice': ['one', 'two'], 'mystr': 'string', 'nested_dict': {'key': 'val'}}: received 1 unexpected positional argument": %!v(MISSING)
TEMPLATE: Items (iter):{% for v in mydict.items() %} {{ v }}{% endfor %}
Items (iter): ['one', 'two'] string {'key': 'val'} 1
```