### PR TITLE
Fix incorrect equality test

### DIFF
--- a/builtins/tests.go
+++ b/builtins/tests.go
@@ -68,7 +68,7 @@ func testDivisibleby(ctx *exec.Context, in *exec.Value, params *exec.VarArgs) (b
 
 func testEqual(ctx *exec.Context, in *exec.Value, params *exec.VarArgs) (bool, error) {
 	param := params.First()
-	return in.Interface() == param.Interface(), nil
+	return in.EqualValueTo(param), nil
 }
 
 func testEven(ctx *exec.Context, in *exec.Value, params *exec.VarArgs) (bool, error) {

--- a/tests/integration/tests_test.go
+++ b/tests/integration/tests_test.go
@@ -174,4 +174,12 @@ var _ = Context("tests", func() {
 		shouldRender(`{{ var2 is integer() }}`, "False")
 		shouldRender(`{{ var3 is integer() }}`, "True")
 	})
+	Context("https://github.com/NikolaLohinski/gonja/issues/63", func() {
+		BeforeEach(func() {
+			*context = exec.NewContext(map[string]interface{}{
+				"var1": uint64(42),
+			})
+		})
+		shouldRender("{{ var1 is eq 42 }}", "True")
+	})
 })


### PR DESCRIPTION
Comparing interface values together will fail if the type are not exactly matched, e.g. uint64 and int. I suspect this would also fail if custom types would be involved. Instead we can reuse Value's EqualValueTo to do the comparison correctly. Fixes #63.