### PR TITLE
Adding support to supress logging

### DIFF
--- a/exec/value.go
+++ b/exec/value.go
@@ -532,7 +532,6 @@ func (v *Value) Contains(other *Value) bool {
 		return false
 
 	default:
-		fmt.Println("default")
 		log.Errorf("Value.Contains() not available for type: %s\n", resolved.Kind().String())
 		return false
 	}

--- a/gonja.go
+++ b/gonja.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"path"
 
 	"github.com/nikolalohinski/gonja/v2/builtins"
 	"github.com/nikolalohinski/gonja/v2/config"
 	"github.com/nikolalohinski/gonja/v2/exec"
 	"github.com/nikolalohinski/gonja/v2/loaders"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -24,6 +26,14 @@ var (
 		Methods:           builtins.Methods,
 	}
 )
+
+func SetLoggerOutput(out io.Writer) {
+	logrus.SetOutput(out)
+}
+
+func SetLoggerLevel(level logrus.Level) {
+	logrus.SetLevel(level)
+}
 
 func FromString(source string) (*exec.Template, error) {
 	return FromBytes([]byte(source))


### PR DESCRIPTION
This PR adds 2 new functions that will allow users to suppress and/or control the logging when they don't want it. It also removes a fmt.Print call that should not have been there.

```
func SetLoggerOutput(out io.Writer) {
	logrus.SetOutput(out)
}

func SetLoggerLevel(level logrus.Level) {
	logrus.SetLevel(level)
}
```