### PR TITLE
fix: make sure int to float comparison behave correctly

### DIFF
--- a/exec/value.go
+++ b/exec/value.go
@@ -742,6 +742,10 @@ func (v *Value) EqualValueTo(other *Value) bool {
 	if v.IsInteger() && other.IsInteger() {
 		return v.Integer() == other.Integer()
 	}
+	// comparison of float with int also fails using .Interface()-comparison
+	if v.IsNumber() && other.IsNumber() {
+		return v.Float() == other.Float()
+	}
 	return v.Interface() == other.Interface()
 }
 

--- a/tests/integration/tests_test.go
+++ b/tests/integration/tests_test.go
@@ -182,4 +182,15 @@ var _ = Context("tests", func() {
 		})
 		shouldRender("{{ var1 is eq 42 }}", "True")
 	})
+	Context("float to int equality", func() {
+		BeforeEach(func() {
+			*context = exec.NewContext(map[string]interface{}{
+				"foo": 42.0,
+			})
+		})
+		shouldRender("{{ foo is eq 42 }}", "True")
+		shouldRender("{{ 42.0 is eq 42 }}", "True")
+		shouldRender("{{ 42 is eq 42.0 }}", "True")
+		shouldRender("{{ 42.5 is eq 42 }}", "False")
+	})
 })

--- a/tests/legacy/testcases/expressions/floats.tpl.out
+++ b/tests/legacy/testcases/expressions/floats.tpl.out
@@ -1,4 +1,4 @@
 5.5
 5.172841
-False
+True
 True


### PR DESCRIPTION
It turns out the previous change in #63 was not completely sufficient: comparison tests should work across all numerical types, including between floating and integer types.