### PR TITLE
Improve Jinja-compatible whitespace handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,14 @@ type Config struct {
 	TrimBlocks bool
 	// If is set to true, the leading spaces and tabes are stripped from the start of a line to a block
 	LeftStripBlocks bool
+	// Preserve a single trailing newline at the end of the template source.
+	KeepTrailingNewline bool
+	// The newline sequence to use in rendered template data and multiline string literals.
+	NewlineSequence string
+	// Prefix that turns an entire line into a statement block when set.
+	LineStatementPrefix string
+	// Prefix that turns the remainder of a line into a comment when set.
+	LineCommentPrefix string
 }
 
 func New() *Config {
@@ -41,6 +49,10 @@ func New() *Config {
 		StrictUndefined:     false,
 		TrimBlocks:          false,
 		LeftStripBlocks:     false,
+		KeepTrailingNewline: false,
+		NewlineSequence:     "\n",
+		LineStatementPrefix: "",
+		LineCommentPrefix:   "",
 	}
 }
 
@@ -56,5 +68,9 @@ func (c *Config) Inherit() *Config {
 		StrictUndefined:     c.StrictUndefined,
 		TrimBlocks:          c.TrimBlocks,
 		LeftStripBlocks:     c.LeftStripBlocks,
+		KeepTrailingNewline: c.KeepTrailingNewline,
+		NewlineSequence:     c.NewlineSequence,
+		LineStatementPrefix: c.LineStatementPrefix,
+		LineCommentPrefix:   c.LineCommentPrefix,
 	}
 }

--- a/exec/renderer.go
+++ b/exec/renderer.go
@@ -62,8 +62,8 @@ func (r *Renderer) Visit(node nodes.Node) (nodes.Visitor, error) {
 	case *nodes.Data:
 		output := n.Data.Val
 		if n.RemoveFirstLineReturn {
-			output = strings.TrimSuffix(output, "\n")
-			output = strings.TrimSuffix(output, "\r\n")
+			output = strings.TrimPrefix(output, "\r\n")
+			output = strings.TrimPrefix(output, "\n")
 		}
 		if n.Trim.Left {
 			output = strings.TrimLeft(output, " \r\n\t")

--- a/parser/control_structure.go
+++ b/parser/control_structure.go
@@ -56,7 +56,6 @@ func (p *Parser) ParseControlStructureBlock() (*nodes.ControlStructureBlock, err
 	}
 	if data := p.Current(tokens.Data); data != nil {
 		data.Trim = data.Trim || len(end.Val) > 0 && end.Val[0] == '-'
-		data.RemoveFirstLineReturn = p.Config.TrimBlocks && len(end.Val) > 0 && end.Val[0] != '+'
 	}
 
 	if logging.Enabled() {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,7 +4,6 @@ package parser
 import (
 	"fmt"
 	"io"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -12,10 +11,6 @@ import (
 	"github.com/nikolalohinski/gonja/v2/loaders"
 	"github.com/nikolalohinski/gonja/v2/nodes"
 	"github.com/nikolalohinski/gonja/v2/tokens"
-)
-
-var (
-	lineReturnWithOnlyWhiteSpace = regexp.MustCompile("^(\n|\r\n)[ \t]*$")
 )
 
 type ControlStructureGetter interface {
@@ -198,13 +193,6 @@ func (p *Parser) parseDocElement() (nodes.Node, error) {
 				n.Trim.Right = true
 			}
 		}
-		if p.Config.LeftStripBlocks {
-			if next := p.Peek(tokens.BlockBegin); next != nil {
-				if len(next.Val) == 0 || next.Val[len(next.Val)-1] != '+' {
-					n.RemoveTrailingWhiteSpaceFromLastLine = true
-				}
-			}
-		}
 		p.Consume()
 		return n, nil
 	case tokens.EOF:
@@ -216,14 +204,6 @@ func (p *Parser) parseDocElement() (nodes.Node, error) {
 		return p.ParseExpressionNode()
 	case tokens.BlockBegin:
 		node, err := p.ParseControlStructureBlock()
-		if err != nil {
-			return node, err
-		}
-		if p.Config.TrimBlocks && !p.End() && p.Peek(tokens.BlockBegin) != nil {
-			if data := p.Current(tokens.Data); data != nil && lineReturnWithOnlyWhiteSpace.MatchString(data.Val) {
-				p.Consume() // Consume whitespace
-			}
-		}
 		return node, err
 	}
 	return nil, p.Error("Unexpected token (only HTML/tags/filters in templates allowed)", t)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -76,8 +76,15 @@ var _ = Context("parser", func() {
 			},
 		},
 		{
-			"is a single quoted string with nested spaces, lines and tabs",
-			[]string{"{{ '  \r\n\ttest' }}", `{{ '  \r\n\ttest' }}`},
+			"is a single quoted string with embedded source newlines",
+			[]string{"{{ '  \r\n\ttest' }}"},
+			[]types.GomegaMatcher{
+				MatchNodeOutput(MatchStringNode("  \n\ttest")),
+			},
+		},
+		{
+			"is a single quoted string with escaped newlines and tabs",
+			[]string{`{{ '  \r\n\ttest' }}`},
 			[]types.GomegaMatcher{
 				MatchNodeOutput(MatchStringNode("  \r\n\ttest")),
 			},

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -90,12 +90,89 @@ var _ = Context("config", func() {
 			Expect(*returnedErr).To(BeNil())
 			By("returning the expected result")
 			expected := heredoc.Doc(`
-
+				
 				I am cornered
 				but pointy
-
 			`)
 			AssertPrettyDiff(expected, *returnedResult)
+		})
+	})
+	Context("when toggling Config.KeepTrailingNewline behavior", func() {
+		BeforeEach(func() {
+			*loader = loaders.MustNewMemoryLoader(map[string]string{
+				*identifier: "with\nnewline\n",
+			})
+		})
+
+		Context("when Config.KeepTrailingNewline = false", func() {
+			It("should drop a single trailing newline", func() {
+				Expect(*returnedErr).To(BeNil())
+				AssertPrettyDiff("with\nnewline", *returnedResult)
+			})
+		})
+
+		Context("when Config.KeepTrailingNewline = true", func() {
+			BeforeEach(func() {
+				(*configuration).KeepTrailingNewline = true
+			})
+
+			It("should preserve the trailing newline", func() {
+				Expect(*returnedErr).To(BeNil())
+				AssertPrettyDiff("with\nnewline\n", *returnedResult)
+			})
+		})
+	})
+	Context("when changing Config.NewlineSequence", func() {
+		BeforeEach(func() {
+			(*configuration).NewlineSequence = "\r\n"
+			*loader = loaders.MustNewMemoryLoader(map[string]string{
+				*identifier: "line1\n{{ \"line2\nline3\" }}",
+			})
+		})
+
+		It("should normalize template data and multiline strings", func() {
+			Expect(*returnedErr).To(BeNil())
+			AssertPrettyDiff("line1\r\nline2\r\nline3", *returnedResult)
+		})
+	})
+	Context("when using Config.LineStatementPrefix", func() {
+		BeforeEach(func() {
+			(*configuration).LineStatementPrefix = "#"
+			*loader = loaders.MustNewMemoryLoader(map[string]string{
+				*identifier: "# for item in [1, 2]\n* {{ item }}\n# endfor",
+			})
+		})
+
+		It("should render line-based statements like block tags", func() {
+			Expect(*returnedErr).To(BeNil())
+			AssertPrettyDiff("* 1\n* 2\n", *returnedResult)
+		})
+	})
+	Context("when using Config.LineCommentPrefix", func() {
+		BeforeEach(func() {
+			(*configuration).LineCommentPrefix = "##"
+			*loader = loaders.MustNewMemoryLoader(map[string]string{
+				*identifier: "## comment\nhello",
+			})
+		})
+
+		It("should ignore the rest of the comment line", func() {
+			Expect(*returnedErr).To(BeNil())
+			AssertPrettyDiff("\nhello", *returnedResult)
+		})
+	})
+	Context("when using PHP-style block delimiters", func() {
+		BeforeEach(func() {
+			(*configuration).BlockStartString = "<?"
+			(*configuration).BlockEndString = "?>"
+			*loader = loaders.MustNewMemoryLoader(map[string]string{
+				*identifier: "<? if True ?>ok<? endif ?>",
+			})
+		})
+
+		It("should parse the template correctly", func() {
+			Expect(*returnedErr).To(BeNil())
+			AssertPrettyDiff("ok", *returnedResult)
 		})
 	})
 	Context("when toggling Config.AutoEscape behavior", func() {
@@ -154,8 +231,7 @@ var _ = Context("config", func() {
 
 					The empty line should have been removed
 
-					The empty line above should stay
-				`), *returnedResult)
+					The empty line above should stay`), *returnedResult)
 			})
 		})
 		Context("when Config.TrimBlocks = true", func() {
@@ -171,8 +247,7 @@ var _ = Context("config", func() {
 						Some text
 						The empty line should have been removed
 
-						The empty line above should stay
-					`), *returnedResult)
+						The empty line above should stay`), *returnedResult)
 				})
 			})
 			Context("when block trimming is disabled locally", func() {
@@ -198,8 +273,7 @@ var _ = Context("config", func() {
 
 						The empty line should have been removed
 
-						The empty line above should stay
-					`), *returnedResult)
+						The empty line above should stay`), *returnedResult)
 				})
 			})
 		})
@@ -225,8 +299,7 @@ var _ = Context("config", func() {
 				AssertPrettyDiff(heredoc.Doc(`
 					  	block indented with spaces and tabs
 					-
-					  variable indented with spaces
-				`), *returnedResult)
+					  variable indented with spaces`), *returnedResult)
 			})
 		})
 		Context("when Config.LeftStripBlocks = true", func() {
@@ -241,8 +314,7 @@ var _ = Context("config", func() {
 					AssertPrettyDiff(heredoc.Doc(`
 						block indented with spaces and tabs
 						-
-						  variable indented with spaces
-					`), *returnedResult)
+						  variable indented with spaces`), *returnedResult)
 				})
 			})
 			Context("when left stripping is disabled locally", func() {
@@ -262,8 +334,7 @@ var _ = Context("config", func() {
 					AssertPrettyDiff(heredoc.Doc(`
 						  	block indented with spaces and tabs
 						-
-						  variable indented with spaces
-					`), *returnedResult)
+						  variable indented with spaces`), *returnedResult)
 				})
 			})
 		})
@@ -293,10 +364,10 @@ var _ = Context("config", func() {
 			Expect(*returnedErr).To(BeNil())
 			By("returning the expected result")
 			expected := heredoc.Doc(`
-				
 				- 1
 				- 2
-				- 3`)
+				- 3
+			`)
 			AssertPrettyDiff(expected, *returnedResult)
 		})
 	})

--- a/tests/integration/control_structure_block_test.go
+++ b/tests/integration/control_structure_block_test.go
@@ -60,8 +60,7 @@ var _ = Context("control structure 'block'", func() {
 				first block
 				second block
 				self first block
-				self second block
-			`)
+				self second block`)
 			AssertPrettyDiff(expected, *returnedResult)
 		})
 	})
@@ -91,8 +90,7 @@ var _ = Context("control structure 'block'", func() {
 				some content in between
 
 				reused content
-				reused content
-			`)
+				reused content`)
 			AssertPrettyDiff(expected, *returnedResult)
 		})
 	})

--- a/tests/integration/dicts_test.go
+++ b/tests/integration/dicts_test.go
@@ -61,8 +61,7 @@ var _ = Context("dicts", func() {
 					['exists']: content
 					['nope']: 
 					["nope"]: 
-					["exi" ~ "sts"]: content
-				`)
+					["exi" ~ "sts"]: content`)
 				AssertPrettyDiff(expected, *returnedResult)
 			})
 		})

--- a/tests/integration/expressions_test.go
+++ b/tests/integration/expressions_test.go
@@ -69,8 +69,7 @@ var _ = Context("expressions", func() {
 				    Negated
 
 				Output 2:
-				    Negated
-			`)
+				    Negated`)
 			AssertPrettyDiff(expected, *returnedResult)
 		})
 	})

--- a/tests/integration/lists_test.go
+++ b/tests/integration/lists_test.go
@@ -59,8 +59,7 @@ var _ = Context("lists", func() {
 					[1]:   2
 					[-2]:  4
 					[256]: 
-					[-99]: 
-				`)
+					[-99]: `)
 				AssertPrettyDiff(expected, *returnedResult)
 			})
 		})
@@ -92,8 +91,7 @@ var _ = Context("lists", func() {
 					[2:]:  [3, 4, 'five']
 					[:3]:  ['1', 2, 3]
 					[:-2]: ['1', 2, 3]
-					[-4:]: [2, 3, 4, 'five']
-				`)
+					[-4:]: [2, 3, 4, 'five']`)
 				AssertPrettyDiff(expected, *returnedResult)
 			})
 		})
@@ -180,8 +178,7 @@ var _ = Context("lists", func() {
 					in: False
 					not in: True
 					is not in: True
-					not (in): True
-				`)
+					not (in): True`)
 			AssertPrettyDiff(expected, *returnedResult)
 		})
 	})

--- a/tests/integration/strings_test.go
+++ b/tests/integration/strings_test.go
@@ -62,8 +62,7 @@ var _ = Context("strings", func() {
 					[4]:   i
 					[-3]:  u
 					[256]: 
-					[-99]: 
-				`)
+					[-99]: `)
 				AssertPrettyDiff(expected, *returnedResult)
 			})
 		})
@@ -94,8 +93,7 @@ var _ = Context("strings", func() {
 					[2:]:  sting is fun!
 					[:3]:  tes
 					[:-2]: testing is fu
-					[-5:]:  fun!
-				`)
+					[-5:]:  fun!`)
 				AssertPrettyDiff(expected, *returnedResult)
 			})
 		})
@@ -220,8 +218,7 @@ var _ = Context("strings", func() {
 				By("returning the expected result")
 				expected := heredoc.Doc(`
 				True
-				bob
-				`)
+				bob`)
 				AssertPrettyDiff(expected, *returnedResult)
 			})
 		})

--- a/tests/legacy/legacy_test.go
+++ b/tests/legacy/legacy_test.go
@@ -29,6 +29,23 @@ var _ = Context("legacy tests", func() {
 		fixturesDir  = "testdata/"
 		testCasesDir = "testcases/"
 	)
+	trimSingleTrailingNewline := func(input string) string {
+		if strings.HasSuffix(input, "\r\n") {
+			return strings.TrimSuffix(input, "\r\n")
+		}
+		return strings.TrimSuffix(input, "\n")
+	}
+	adjustExpectedTrailingNewline := func(expected, source string, cfg *config.Config) string {
+		if cfg == nil || cfg.KeepTrailingNewline {
+			return expected
+		}
+		source = strings.ReplaceAll(source, "\r\n", "\n")
+		source = strings.ReplaceAll(source, "\r", "\n")
+		if !strings.HasSuffix(source, "\n") {
+			return expected
+		}
+		return trimSingleTrailingNewline(expected)
+	}
 	var (
 		identifier = new(string)
 
@@ -44,7 +61,8 @@ var _ = Context("legacy tests", func() {
 	BeforeEach(func() {
 		*identifier = "/test"
 		*environment = gonja.DefaultEnvironment
-		*config = gonja.DefaultConfig
+		*config = gonja.DefaultConfig.Inherit()
+		(*config).KeepTrailingNewline = true
 		*loader = loaders.MustNewMemoryLoader(nil)
 	})
 	JustBeforeEach(func() {
@@ -71,7 +89,9 @@ var _ = Context("legacy tests", func() {
 					By("not returning any error")
 					Expect(*returnedErr).To(BeNil())
 					By("returning the correct result")
+					source := string(MustReturn(os.ReadFile(filePath)).([]byte))
 					expected := string(MustReturn(os.ReadFile(filePath + ".out")).([]byte))
+					expected = adjustExpectedTrailingNewline(expected, source, *config)
 					edits := myers.ComputeEdits("expected", expected, *returnedResult)
 					diffs := gotextdiff.ToUnified("expected", "got", expected, edits)
 					Expect(diffs.Hunks).To(BeEmpty(), "\n"+fmt.Sprint(diffs))
@@ -494,8 +514,9 @@ var _ = Context("legacy tests", func() {
 					By("not returning any error")
 					Expect(*returnedErr).To(BeNil())
 					By("not returning the correct result")
-					edits := myers.ComputeEdits("expected", t.expected, *returnedResult)
-					diffs := gotextdiff.ToUnified("expected", "got", t.expected, edits)
+					expected := adjustExpectedTrailingNewline(t.expected, t.template, *config)
+					edits := myers.ComputeEdits("expected", expected, *returnedResult)
+					diffs := gotextdiff.ToUnified("expected", "got", expected, edits)
 					Expect(diffs.Hunks).To(BeEmpty(), "\n"+fmt.Sprint(diffs))
 				})
 			})

--- a/tokens/lexer.go
+++ b/tokens/lexer.go
@@ -44,26 +44,49 @@ type Lexer struct {
 	delimiters           []rune
 	RawControlStructures rawControlStructure
 	rawEnd               *regexp.Regexp
+	expressionEnd        Type
+	lineStatement        bool
 }
 
 // TODO: set from env
 type rawControlStructure map[string]*regexp.Regexp
 
-func escapeCharsClashingRegexp(s string) string {
-	s = strings.ReplaceAll(s, "[", "\\[")
-	s = strings.ReplaceAll(s, "]", "\\]")
-	return s
+func normalizeInput(input string, cfg *config.Config) string {
+	input = strings.ReplaceAll(input, "\r\n", "\n")
+	input = strings.ReplaceAll(input, "\r", "\n")
+	if !cfg.KeepTrailingNewline && strings.HasSuffix(input, "\n") {
+		input = input[:len(input)-1]
+	}
+	return input
+}
+
+func normalizeNewlines(input, newline string) string {
+	if newline == "" || newline == "\n" {
+		return input
+	}
+	return strings.ReplaceAll(input, "\n", newline)
+}
+
+func trimLeadingWhitespaceFromLastLine(input string) string {
+	lineStart := strings.LastIndex(input, "\n") + 1
+	for i := lineStart; i < len(input); i++ {
+		if input[i] != ' ' && input[i] != '\t' {
+			return input
+		}
+	}
+	return input[:lineStart]
 }
 
 // NewLexer creates a new scanner for the input string.
 func NewLexer(input string, config *config.Config) *Lexer {
+	normalizedInput := normalizeInput(input, config)
 	return &Lexer{
-		Input:  input,
+		Input:  normalizedInput,
 		Tokens: make(chan *Token),
 		Config: config,
 		RawControlStructures: rawControlStructure{
-			"raw":     regexp.MustCompile(fmt.Sprintf(`%s-?\s*endraw`, escapeCharsClashingRegexp(config.BlockStartString))),
-			"comment": regexp.MustCompile(fmt.Sprintf(`%s-?\s*endcomment`, escapeCharsClashingRegexp(config.BlockStartString))),
+			"raw":     regexp.MustCompile(fmt.Sprintf(`%s[-+]?\s*endraw`, regexp.QuoteMeta(config.BlockStartString))),
+			"comment": regexp.MustCompile(fmt.Sprintf(`%s[-+]?\s*endcomment`, regexp.QuoteMeta(config.BlockStartString))),
 		},
 	}
 }
@@ -176,6 +199,197 @@ func (l *Lexer) hasPrefix(prefix string) bool {
 	return strings.HasPrefix(l.Input[l.Pos:], prefix)
 }
 
+func (l *Lexer) hasPrefixAt(pos int, prefix string) bool {
+	if pos < 0 || pos > len(l.Input) {
+		return false
+	}
+	return strings.HasPrefix(l.Input[pos:], prefix)
+}
+
+func (l *Lexer) atLineStart(pos int) bool {
+	return pos == 0 || l.Input[pos-1] == '\n'
+}
+
+func (l *Lexer) emitData(stripLeadingWhitespace bool) {
+	if l.Pos <= l.Start {
+		return
+	}
+	line, col := ReadablePosition(l.Start, l.Input)
+	val := l.Input[l.Start:l.Pos]
+	if stripLeadingWhitespace {
+		val = trimLeadingWhitespaceFromLastLine(val)
+	}
+	val = normalizeNewlines(val, l.Config.NewlineSequence)
+	if val == "" {
+		l.Start = l.Pos
+		return
+	}
+	l.Tokens <- &Token{
+		Type: Data,
+		Val:  val,
+		Pos:  l.Start,
+		Line: line,
+		Col:  col,
+	}
+	l.Start = l.Pos
+}
+
+func (l *Lexer) consumeWhitespaceControl(allowed string) byte {
+	if l.Pos >= len(l.Input) {
+		return 0
+	}
+	control := l.Input[l.Pos]
+	if !strings.ContainsRune(allowed, rune(control)) {
+		return 0
+	}
+	l.Pos++
+	return control
+}
+
+func (l *Lexer) openingWhitespaceControl(prefix string) byte {
+	pos := l.Pos + len(prefix)
+	if pos >= len(l.Input) {
+		return 0
+	}
+	control := l.Input[pos]
+	if control != '-' && control != '+' {
+		return 0
+	}
+	return control
+}
+
+func (l *Lexer) consumeFollowingNewline() {
+	if l.hasPrefix("\n") {
+		l.Pos++
+		l.Start = l.Pos
+	}
+}
+
+type rootTokenKind int
+
+const (
+	rootTokenNone rootTokenKind = iota
+	rootTokenComment
+	rootTokenVariable
+	rootTokenBlock
+)
+
+func (l *Lexer) currentRootToken() rootTokenKind {
+	var (
+		longest int
+		kind    rootTokenKind
+	)
+	for _, candidate := range []struct {
+		prefix string
+		kind   rootTokenKind
+	}{
+		{l.Config.CommentStartString, rootTokenComment},
+		{l.Config.VariableStartString, rootTokenVariable},
+		{l.Config.BlockStartString, rootTokenBlock},
+	} {
+		if candidate.prefix == "" || !l.hasPrefix(candidate.prefix) {
+			continue
+		}
+		if len(candidate.prefix) > longest {
+			longest = len(candidate.prefix)
+			kind = candidate.kind
+		}
+	}
+	return kind
+}
+
+type linePrefixKind int
+
+const (
+	linePrefixNone linePrefixKind = iota
+	linePrefixStatement
+	linePrefixComment
+)
+
+func (l *Lexer) currentLinePrefix() (linePrefixKind, bool) {
+	if !l.atLineStart(l.Pos) {
+		return linePrefixNone, false
+	}
+	prefixPos := l.Pos
+	for prefixPos < len(l.Input) && isLinePrefixSpace(rune(l.Input[prefixPos])) {
+		prefixPos++
+	}
+	var (
+		longest int
+		kind    linePrefixKind
+	)
+	for _, candidate := range []struct {
+		prefix string
+		kind   linePrefixKind
+	}{
+		{l.Config.LineStatementPrefix, linePrefixStatement},
+		{l.Config.LineCommentPrefix, linePrefixComment},
+	} {
+		if candidate.prefix == "" || !l.hasPrefixAt(prefixPos, candidate.prefix) {
+			continue
+		}
+		if len(candidate.prefix) > longest {
+			longest = len(candidate.prefix)
+			kind = candidate.kind
+		}
+	}
+	return kind, kind != linePrefixNone
+}
+
+func (l *Lexer) hasInlineLineComment() bool {
+	if l.Config.LineCommentPrefix == "" || l.Pos == 0 || l.atLineStart(l.Pos) {
+		return false
+	}
+	prev, _ := utf8.DecodeLastRuneInString(l.Input[:l.Pos])
+	if prev == '\n' || isLinePrefixSpace(prev) {
+		return false
+	}
+	prefixPos := l.Pos
+	for prefixPos < len(l.Input) && isLinePrefixSpace(rune(l.Input[prefixPos])) {
+		prefixPos++
+	}
+	return l.hasPrefixAt(prefixPos, l.Config.LineCommentPrefix)
+}
+
+func (l *Lexer) lineStatementEndLength() (int, bool) {
+	remaining := l.remaining()
+	newlineIdx := strings.IndexByte(remaining, '\n')
+	tail := remaining
+	endLength := len(remaining)
+	if newlineIdx >= 0 {
+		tail = remaining[:newlineIdx]
+		endLength = newlineIdx + 1
+	}
+	if !isLineStatementClosingTail(tail) {
+		return 0, false
+	}
+	return endLength, true
+}
+
+func isLineStatementClosingTail(tail string) bool {
+	index := 0
+	for index < len(tail) && isLinePrefixSpace(rune(tail[index])) {
+		index++
+	}
+	if index == len(tail) {
+		return true
+	}
+	colons := index
+	for colons < len(tail) && tail[colons] == ':' {
+		colons++
+	}
+	if colons == index {
+		return false
+	}
+	for colons < len(tail) {
+		if !isLinePrefixSpace(rune(tail[colons])) {
+			return false
+		}
+		colons++
+	}
+	return true
+}
+
 func (l *Lexer) popDelimiter(r rune) bool {
 	if len(l.delimiters) == 0 {
 		l.errorf(`Unexpected delimiter "%c"`, r)
@@ -203,25 +417,29 @@ func (l *Lexer) expectDelimiter(r rune) bool {
 
 func (l *Lexer) lexData() lexFn {
 	for {
-		if l.hasPrefix(l.Config.CommentStartString) {
-			if l.Pos > l.Start {
-				l.emit(Data)
-			}
+		switch l.currentRootToken() {
+		case rootTokenComment:
+			l.emitData(l.Config.LeftStripBlocks && l.openingWhitespaceControl(l.Config.CommentStartString) != '+')
 			return l.lexComment
-		}
-
-		if l.hasPrefix(l.Config.VariableStartString) {
-			if l.Pos > l.Start {
-				l.emit(Data)
-			}
+		case rootTokenVariable:
+			l.emitData(false)
 			return l.lexVariable
+		case rootTokenBlock:
+			l.emitData(l.Config.LeftStripBlocks && l.openingWhitespaceControl(l.Config.BlockStartString) != '+')
+			return l.lexBlock
 		}
 
-		if l.hasPrefix(l.Config.BlockStartString) {
-			if l.Pos > l.Start {
-				l.emit(Data)
+		if prefix, ok := l.currentLinePrefix(); ok {
+			l.emitData(false)
+			if prefix == linePrefixComment {
+				return l.lexLineComment
 			}
-			return l.lexBlock
+			return l.lexLineStatement
+		}
+
+		if l.hasInlineLineComment() {
+			l.emitData(false)
+			return l.lexLineComment
 		}
 
 		if l.next() == rEOF {
@@ -229,9 +447,7 @@ func (l *Lexer) lexData() lexFn {
 		}
 	}
 	// Correctly reached EOF.
-	if l.Pos > l.Start {
-		l.emit(Data)
-	}
+	l.emitData(false)
 	l.emit(EOF) // Useful to make EOF a token.
 	return nil  // Stop the run loop.
 }
@@ -246,7 +462,7 @@ func (l *Lexer) lexRaw() lexFn {
 		return l.errorf(`Unable to find raw closing controlStructure`)
 	}
 	l.Pos += loc[0]
-	l.emit(Data)
+	l.emitData(false)
 	l.rawEnd = nil
 	return l.lexBlock
 	// regexp.MustCompile(`(?m)(?P<key>\w+):\s+(?P<value>\w+)$`)
@@ -255,20 +471,25 @@ func (l *Lexer) lexRaw() lexFn {
 
 func (l *Lexer) lexComment() lexFn {
 	l.Pos += len(l.Config.CommentStartString)
-	l.accept("-")
+	l.consumeWhitespaceControl("-+")
 	l.emit(CommentBegin)
 	i := strings.Index(l.Input[l.Pos:], l.Config.CommentEndString)
 	if i < 0 {
 		return l.errorf("unclosed comment")
 	}
-	l.Pos += i
-	if l.Input[l.Pos-1] == '-' {
-		l.Pos -= 1
+	contentEnd := l.Pos + i
+	if contentEnd > l.Start && (l.Input[contentEnd-1] == '-' || l.Input[contentEnd-1] == '+') {
+		contentEnd--
 	}
-	l.emit(Data)
-	l.accept("-")
+	l.Pos = contentEnd
+	l.emitData(false)
+	l.Pos = contentEnd
+	control := l.consumeWhitespaceControl("-+")
 	l.Pos += len(l.Config.CommentEndString)
 	l.emit(CommentEnd)
+	if l.Config.TrimBlocks && control != '+' {
+		l.consumeFollowingNewline()
+	}
 	return l.lexData
 }
 
@@ -282,6 +503,7 @@ func (l *Lexer) lexVariable() lexFn {
 	}
 	l.Pos += len(l.Config.VariableStartString)
 	l.accept("-")
+	l.expressionEnd = VariableEnd
 	l.emit(VariableBegin)
 	return l.lexExpression
 }
@@ -295,8 +517,8 @@ func (l *Lexer) lexVariableEnd() lexFn {
 
 func (l *Lexer) lexBlock() lexFn {
 	l.Pos += len(l.Config.BlockStartString)
-	l.accept("-")
-	l.accept("+")
+	l.consumeWhitespaceControl("-+")
+	l.expressionEnd = BlockEnd
 	l.emit(BlockBegin)
 	for isSpace(l.peek()) {
 		l.next()
@@ -313,11 +535,52 @@ func (l *Lexer) lexBlock() lexFn {
 	return l.lexExpression
 }
 
+func (l *Lexer) lexLineStatement() lexFn {
+	for isLinePrefixSpace(l.peek()) {
+		l.next()
+	}
+	l.Start = l.Pos
+	l.Pos += len(l.Config.LineStatementPrefix)
+	l.expressionEnd = BlockEnd
+	l.lineStatement = true
+	l.emit(BlockBegin)
+	for isSpace(l.peek()) {
+		l.next()
+	}
+	if len(l.Current()) > 0 {
+		l.emit(Whitespace)
+	}
+	controlStructure := l.nextIdentifier()
+	l.emit(Name)
+	if re, exists := l.RawControlStructures[controlStructure]; exists {
+		l.rawEnd = re
+	}
+	return l.lexExpression
+}
+
+func (l *Lexer) lexLineComment() lexFn {
+	for isLinePrefixSpace(l.peek()) {
+		l.next()
+	}
+	l.Pos += len(l.Config.LineCommentPrefix)
+	for {
+		r := l.peek()
+		if r == '\n' || r == rEOF {
+			break
+		}
+		l.next()
+	}
+	l.Start = l.Pos
+	return l.lexData
+}
+
 func (l *Lexer) lexBlockEnd() lexFn {
-	l.accept("-")
-	l.accept("+")
+	control := l.consumeWhitespaceControl("-+")
 	l.Pos += len(l.Config.BlockEndString)
 	l.emit(BlockEnd)
+	if l.Config.TrimBlocks && control != '+' {
+		l.consumeFollowingNewline()
+	}
 	if l.rawEnd != nil {
 		return l.lexRaw
 	} else {
@@ -334,12 +597,21 @@ func (l *Lexer) lexExpression() lexFn {
 		}).Trace("lexExpression")
 	}
 	for {
+		if len(l.delimiters) == 0 && l.lineStatement {
+			if endLength, ok := l.lineStatementEndLength(); ok {
+				l.Pos += endLength
+				l.lineStatement = false
+				l.emit(BlockEnd)
+				return l.lexData
+			}
+		}
+
 		if !l.expectDelimiter(l.peek()) {
-			if l.hasPrefix(l.Config.VariableEndString) {
+			if l.expressionEnd == VariableEnd && l.hasPrefix(l.Config.VariableEndString) {
 				return l.lexVariableEnd
 			}
 
-			if l.hasPrefix(l.Config.BlockEndString) {
+			if l.expressionEnd == BlockEnd && l.hasPrefix(l.Config.BlockEndString) {
 				return l.lexBlockEnd
 			}
 		}
@@ -565,12 +837,18 @@ func (l *Lexer) lexString() lexFn {
 			return l.errorf(`%s`, string(near))
 		}
 	}
-	l.processAndEmit(String, unescape)
+	l.processAndEmit(String, func(value string) string {
+		return normalizeNewlines(unescape(value), l.Config.NewlineSequence)
+	})
 	return l.lexExpression
 }
 
 // isSpace reports whether r is a space character.
 func isSpace(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+func isLinePrefixSpace(r rune) bool {
 	return r == ' ' || r == '\t'
 }
 

--- a/tokens/lexer.go
+++ b/tokens/lexer.go
@@ -210,15 +210,19 @@ func (l *Lexer) atLineStart(pos int) bool {
 	return pos == 0 || l.Input[pos-1] == '\n'
 }
 
-func (l *Lexer) emitData(stripLeadingWhitespace bool) {
+func (l *Lexer) emitData() {
+	l.emitDataValue(l.Input[l.Start:l.Pos])
+}
+
+func (l *Lexer) emitLeftStrippedData() {
+	l.emitDataValue(trimLeadingWhitespaceFromLastLine(l.Input[l.Start:l.Pos]))
+}
+
+func (l *Lexer) emitDataValue(val string) {
 	if l.Pos <= l.Start {
 		return
 	}
 	line, col := ReadablePosition(l.Start, l.Input)
-	val := l.Input[l.Start:l.Pos]
-	if stripLeadingWhitespace {
-		val = trimLeadingWhitespaceFromLastLine(val)
-	}
 	val = normalizeNewlines(val, l.Config.NewlineSequence)
 	if val == "" {
 		l.Start = l.Pos
@@ -246,7 +250,7 @@ func (l *Lexer) consumeWhitespaceControl(allowed string) byte {
 	return control
 }
 
-func (l *Lexer) openingWhitespaceControl(prefix string) byte {
+func (l *Lexer) getOpeningWhitespaceControl(prefix string) byte {
 	pos := l.Pos + len(prefix)
 	if pos >= len(l.Input) {
 		return 0
@@ -419,18 +423,26 @@ func (l *Lexer) lexData() lexFn {
 	for {
 		switch l.currentRootToken() {
 		case rootTokenComment:
-			l.emitData(l.Config.LeftStripBlocks && l.openingWhitespaceControl(l.Config.CommentStartString) != '+')
+			if l.Config.LeftStripBlocks && l.getOpeningWhitespaceControl(l.Config.CommentStartString) != '+' {
+				l.emitLeftStrippedData()
+			} else {
+				l.emitData()
+			}
 			return l.lexComment
 		case rootTokenVariable:
-			l.emitData(false)
+			l.emitData()
 			return l.lexVariable
 		case rootTokenBlock:
-			l.emitData(l.Config.LeftStripBlocks && l.openingWhitespaceControl(l.Config.BlockStartString) != '+')
+			if l.Config.LeftStripBlocks && l.getOpeningWhitespaceControl(l.Config.BlockStartString) != '+' {
+				l.emitLeftStrippedData()
+			} else {
+				l.emitData()
+			}
 			return l.lexBlock
 		}
 
 		if prefix, ok := l.currentLinePrefix(); ok {
-			l.emitData(false)
+			l.emitData()
 			if prefix == linePrefixComment {
 				return l.lexLineComment
 			}
@@ -438,7 +450,7 @@ func (l *Lexer) lexData() lexFn {
 		}
 
 		if l.hasInlineLineComment() {
-			l.emitData(false)
+			l.emitData()
 			return l.lexLineComment
 		}
 
@@ -447,7 +459,7 @@ func (l *Lexer) lexData() lexFn {
 		}
 	}
 	// Correctly reached EOF.
-	l.emitData(false)
+	l.emitData()
 	l.emit(EOF) // Useful to make EOF a token.
 	return nil  // Stop the run loop.
 }
@@ -462,7 +474,7 @@ func (l *Lexer) lexRaw() lexFn {
 		return l.errorf(`Unable to find raw closing controlStructure`)
 	}
 	l.Pos += loc[0]
-	l.emitData(false)
+	l.emitData()
 	l.rawEnd = nil
 	return l.lexBlock
 	// regexp.MustCompile(`(?m)(?P<key>\w+):\s+(?P<value>\w+)$`)
@@ -482,7 +494,7 @@ func (l *Lexer) lexComment() lexFn {
 		contentEnd--
 	}
 	l.Pos = contentEnd
-	l.emitData(false)
+	l.emitData()
 	l.Pos = contentEnd
 	control := l.consumeWhitespaceControl("-+")
 	l.Pos += len(l.Config.CommentEndString)

--- a/tokens/lexer_test.go
+++ b/tokens/lexer_test.go
@@ -434,8 +434,8 @@ var _ = Context("lexer", func() {
 					{"Type": Equal(tokens.CommentBegin), "Val": Equal("{#"), "Pos": Equal(6), "Line": Equal(2), "Col": Equal(1)},
 					{"Type": Equal(tokens.Data), "Val": Equal("\n    Multiline comment\n"), "Pos": Equal(8), "Line": Equal(2), "Col": Equal(3)},
 					{"Type": Equal(tokens.CommentEnd), "Val": Equal("#}"), "Pos": Equal(31), "Line": Equal(4), "Col": Equal(1)},
-					{"Type": Equal(tokens.Data), "Val": Equal("\nWorld\n"), "Pos": Equal(33), "Line": Equal(4), "Col": Equal(3)},
-					{"Type": Equal(tokens.EOF), "Val": Equal(""), "Pos": Equal(40), "Line": Equal(6), "Col": Equal(1)},
+					{"Type": Equal(tokens.Data), "Val": Equal("\nWorld"), "Pos": Equal(33), "Line": Equal(4), "Col": Equal(3)},
+					{"Type": Equal(tokens.EOF), "Val": Equal(""), "Pos": Equal(39), "Line": Equal(5), "Col": Equal(6)},
 				},
 			},
 		} {
@@ -517,6 +517,30 @@ var _ = Context("lexer", func() {
 						"Type": Equal(tokens.CommentEnd),
 					})),
 					"13": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(tokens.EOF),
+					})),
+				},
+			))
+		})
+	})
+	Context("when trimming comments aggressively", func() {
+		BeforeEach(func() {
+			*lexer = tokens.NewLexer("{#-#}", config.New())
+		})
+
+		It("should not panic and should return the expected tokens", func() {
+			Expect(*returnedTokens).To(MatchAllElementsWithIndex(
+				func(index int, _ any) string { return strconv.Itoa(index) },
+				Elements{
+					"0": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(tokens.CommentBegin),
+						"Val":  Equal("{#-"),
+					})),
+					"1": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(tokens.CommentEnd),
+						"Val":  Equal("#}"),
+					})),
+					"2": PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type": Equal(tokens.EOF),
 					})),
 				},


### PR DESCRIPTION
This PR brings Gonja closer to Jinja for whitespace and alternate syntax handling.

It adds support for:
- `keep_trailing_newline`
- `newline_sequence`
- `line_statement_prefix`
- `line_comment_prefix`

It also moves `trim_blocks` / `lstrip_blocks` handling into the lexer, improves custom delimiter handling, and fixes a lexer panic around trimmed comments.

## Examples
Jinja drops a single trailing newline by default:

```python
Template("with\nnewline\n").render() == "with\nnewline"
```

Gonja now matches that default.

With `trim_blocks=True` and `lstrip_blocks=True`, this:

```jinja
{% for x in [1,2,3] %}
{{ x }}
{% endfor %}
```

now renders like Jinja:

```text
1
2
3
```

Jinja line statements:

```jinja
# for item in [1, 2]
* {{ item }}
# endfor
```

now render as:

```text
* 1
* 2
```

Jinja line comments:

```jinja
## comment
hello
```

now behave like Jinja and render:

```text

hello
```

Custom block delimiters now parse reliably, for example:

```jinja
<? if True ?>ok<? endif ?>
```

renders:

```text
ok
```

## Testing
- `go test ./...`

## Disclaimer
This PR is heavily AI-generated, I barely touched the code. I am trying to bring Gonja into a higher parity with Jinja to use it further and wanted to contribute back. I did review the code myself and it generally seemed reasonable. Given that all the existing test pass and the new behavior is covered with further tests, I hope it also seems reasonable to you. Happy to take your feedback.
