### PR TITLE
fix(exec, set): Pythonic truthiness for or/and operands and set-ternary cond (closes #86)

### DIFF
--- a/builtins/control_structures/set.go
+++ b/builtins/control_structures/set.go
@@ -34,7 +34,12 @@ func (scs *SetControlStructure) Execute(r *exec.Renderer, tag *nodes.ControlStru
 		if condition.IsError() {
 			return condition
 		}
-		if condition.Bool() {
+		// IsTrue (not Bool) — Bool only returns true for reflect.Bool
+		// kinds, which means `{% set v = X if 1 else Y %}` and any
+		// other non-bool condition (string, int, list, map) silently
+		// took the else branch. Matches the {{ X if c else Y }}
+		// renderer at exec/renderer.go which already uses IsTrue.
+		if !condition.IsNil() && condition.IsTrue() {
 			value = r.Eval(scs.expression)
 		} else {
 			value = r.Eval(scs.alternative)

--- a/exec/evaluator.go
+++ b/exec/evaluator.go
@@ -155,23 +155,30 @@ func (e *Evaluator) evalBinaryExpression(node *nodes.BinaryExpression) *Value {
 	case tokens.Tilde:
 		return AsValue(strings.Join([]string{left.String(), right.String()}, ""))
 	case tokens.And:
+		// Python/Jinja2 semantics: `x and y` returns x if x is falsy,
+		// otherwise y. The result is the operand value, not a coerced bool,
+		// so `{{ '' and 'fallback' }}` renders ''  and `{{ 'a' and 'b' }}`
+		// renders 'b'. Short-circuit on the left.
 		if !left.IsTrue() {
-			return AsValue(false)
+			return left
 		}
 		right = e.Eval(node.Right)
 		if right.IsError() {
 			return AsValue(errors.Wrapf(right, `Unable to evaluate right parameter %s`, node.Right))
 		}
-		return AsValue(right.IsTrue())
+		return right
 	case tokens.Or:
+		// Python/Jinja2 semantics: `x or y` returns x if x is truthy,
+		// otherwise y. So `{{ '' or 'fallback' }}` renders 'fallback' and
+		// `{{ 'a' or 'b' }}` renders 'a'. Short-circuit on the left.
 		if left.IsTrue() {
-			return AsValue(true)
+			return left
 		}
 		right = e.Eval(node.Right)
 		if right.IsError() {
 			return AsValue(errors.Wrapf(right, `Unable to evaluate right parameter %s`, node.Right))
 		}
-		return AsValue(right.IsTrue())
+		return right
 	case tokens.LowerThanOrEqual:
 		if left.IsFloat() || right.IsFloat() {
 			return AsValue(left.Float() <= right.Float())

--- a/tests/integration/expressions_test.go
+++ b/tests/integration/expressions_test.go
@@ -162,4 +162,35 @@ var _ = Context("expressions", func() {
 			AssertPrettyDiff(expected, *returnedResult)
 		})
 	})
+	Context("`{% set v = X if cond else Y %}` honors Pythonic truthiness on cond", func() {
+		// Regression: SetControlStructure.Execute previously used
+		// Value.Bool() which returns true only for reflect.Bool kinds,
+		// silently routing every non-bool-typed condition (int 1,
+		// non-empty string, populated list/map, struct) to the else
+		// branch. Now uses IsTrue() to match the {{ X if c else Y }}
+		// renderer behavior.
+		DescribeTable(
+			"set + ternary with truthy non-bool conditions resolves the X branch",
+			func(template, expected string, ctxKV map[string]interface{}) {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{*identifier: template})
+				for k, v := range ctxKV {
+					(*environment).Context.Set(k, v)
+				}
+				t, err := exec.NewTemplate(*identifier, *configuration, *loader, *environment)
+				Expect(err).To(BeNil())
+				out, err := t.ExecuteToString(*context)
+				Expect(err).To(BeNil())
+				AssertPrettyDiff(expected, out)
+			},
+			Entry("int 1 condition", `{% set v = 'X' if 1 else 'Y' %}{{ v }}`, "X", nil),
+			Entry("string condition", `{% set v = 'X' if 'truthy' else 'Y' %}{{ v }}`, "X", nil),
+			Entry("list condition", `{% set v = 'X' if [1] else 'Y' %}{{ v }}`, "X", nil),
+			Entry("`and` chain returning string", `{% set v = 'X' if ('hello' and 'world') else 'Y' %}{{ v }}`, "X", nil),
+			Entry("attribute access X branch", `{% set v = a.b if 1 else 'Y' %}{{ v }}`, "Z",
+				map[string]interface{}{"a": map[string]interface{}{"b": "Z"}}),
+			Entry("falsy int 0 still goes else", `{% set v = 'X' if 0 else 'Y' %}{{ v }}`, "Y", nil),
+			Entry("empty string still goes else", `{% set v = 'X' if '' else 'Y' %}{{ v }}`, "Y", nil),
+			Entry("empty list still goes else", `{% set v = 'X' if [] else 'Y' %}{{ v }}`, "Y", nil),
+		)
+	})
 })

--- a/tests/integration/expressions_test.go
+++ b/tests/integration/expressions_test.go
@@ -73,6 +73,76 @@ var _ = Context("expressions", func() {
 			AssertPrettyDiff(expected, *returnedResult)
 		})
 	})
+	Context("https://github.com/NikolaLohinski/gonja/issues/86", func() {
+		// Python/Jinja2 `or` and `and` are value-preserving short-circuit
+		// operators: they return one of the operands, not a coerced bool.
+		Context("`or` returns the first truthy operand", func() {
+			BeforeEach(func() {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{
+					*identifier: `{{ 'first' or 'fallback' }}`,
+				})
+			})
+			It("renders 'first'", func() {
+				Expect(*returnedErr).To(BeNil())
+				AssertPrettyDiff("first", *returnedResult)
+			})
+		})
+		Context("`or` falls through when the left side is empty", func() {
+			BeforeEach(func() {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{
+					*identifier: `{{ '' or 'fallback' }}`,
+				})
+			})
+			It("renders 'fallback'", func() {
+				Expect(*returnedErr).To(BeNil())
+				AssertPrettyDiff("fallback", *returnedResult)
+			})
+		})
+		Context("`or` falls through when the left side is undefined", func() {
+			BeforeEach(func() {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{
+					*identifier: `{{ missing or 'fallback' }}`,
+				})
+			})
+			It("renders 'fallback'", func() {
+				Expect(*returnedErr).To(BeNil())
+				AssertPrettyDiff("fallback", *returnedResult)
+			})
+		})
+		Context("`and` returns the last operand when both are truthy", func() {
+			BeforeEach(func() {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{
+					*identifier: `{{ 'first' and 'last' }}`,
+				})
+			})
+			It("renders 'last'", func() {
+				Expect(*returnedErr).To(BeNil())
+				AssertPrettyDiff("last", *returnedResult)
+			})
+		})
+		Context("`and` short-circuits on the first falsy operand", func() {
+			BeforeEach(func() {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{
+					*identifier: `{{ '' and 'never' }}`,
+				})
+			})
+			It("renders an empty string", func() {
+				Expect(*returnedErr).To(BeNil())
+				AssertPrettyDiff("", *returnedResult)
+			})
+		})
+		Context("`or` chains preserve the first truthy value", func() {
+			BeforeEach(func() {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{
+					*identifier: `{{ '' or 0 or 'winner' or 'never' }}`,
+				})
+			})
+			It("renders 'winner'", func() {
+				Expect(*returnedErr).To(BeNil())
+				AssertPrettyDiff("winner", *returnedResult)
+			})
+		})
+	})
 	Context("https://github.com/NikolaLohinski/gonja/issues/40", func() {
 		BeforeEach(func() {
 			*loader = loaders.MustNewMemoryLoader(map[string]string{

--- a/tests/legacy/testcases/expressions/logic.tpl.out
+++ b/tests/legacy/testcases/expressions/logic.tpl.out
@@ -4,4 +4,3 @@ True
 False
 True
 True
-False


### PR DESCRIPTION
Closes #86

## Problem

Two related Pythonic-truthiness regressions in gonja v2.8.0, both caught by the same parity-test surface:

### 1. `or` / `and` coerce to bool

In Python (and Jinja2 by inheritance), `or` and `and` are **value-preserving short-circuit operators** — they return one of the operands as-is, not a coerced bool. gonja returns a `bool`, which breaks the canonical fallback idiom `{{ value or default }}`:

| expression | python | gonja v2.8.0 | this PR |
|---|---|---|---|
| `{{ 'first' or 'fallback' }}` | `'first'` | `'True'` | `'first'` |
| `{{ '' or 'fallback' }}` | `'fallback'` | `'True'` | `'fallback'` |
| `{{ 'first' and 'last' }}` | `'last'` | `'True'` | `'last'` |
| `{{ '' and 'never' }}` | `''` | `'False'` | `''` |

### 2. `{% set v = X if cond else Y %}` only honors bool conditions

`SetControlStructure.Execute` evaluates the ternary condition with `Value.Bool()`, which only returns true for `reflect.Bool` kinds. Every non-bool-typed condition silently routes to the else branch:

| expression | python | gonja v2.8.0 | this PR |
|---|---|---|---|
| `{% set v = 'X' if 1 else 'Y' %}` | `X` | `Y` | `X` |
| `{% set v = 'X' if 'truthy' else 'Y' %}` | `X` | `Y` | `X` |
| `{% set v = 'X' if [1] else 'Y' %}` | `X` | `Y` | `X` |
| `{% set v = obj.attr if 1 else 'Y' %}` | `obj.attr` | `Y` | `obj.attr` |

Notably the **`{{ X if c else Y }}` output renderer** at `exec/renderer.go:88` already uses `IsTrue()` — so the two paths were inconsistent. `set` is now consistent with output.

## Fix

Two small, independent commits:

1. `or` / `and`: return the actual `*Value` operand on each branch instead of `AsValue(true|false|right.IsTrue())`. Short-circuit semantics are unchanged.
2. `set` ternary: replace `condition.Bool()` with `!IsNil() && IsTrue()` to match the output-renderer path.

## Tests

- Six new cases for `or`/`and` value preservation (or-truthy, or-falsy-string, or-undefined, and-truthy-pair, and-short-circuit, or-chain) — linked to issue #86.
- New `DescribeTable` block for `set` ternary with int / string / list / and-chain / attribute-access X branches plus the falsy-still-goes-else cases.
- The legacy `logic.tpl.out` fixture was updated: `{{ None and True }}` now produces the empty string (the `None` operand passing through gonja's existing nil rendering), instead of the previously-coerced `"False"`. The other six lines in that fixture continue to render unchanged because their operands happen to *be* booleans.
- Full `go test ./...` suite green.

## Verified against

End-to-end parity test against ~600 real production templates being migrated from Python Jinja2 to gonja. Without these fixes, every template that uses `{{ x or fallback }}` produces literal `"True"` strings in the rendered HTML, and every `{% set v = X if obj.attr else Y %}` falls through to the else branch. With both fixes the parity matches Python.

---
*Submitted by [Claude Code](https://claude.com/claude-code) on behalf of @brianwawok / Listing Mirror.*
