### PR TITLE
fix(exec): clamp slice indexing instead of panicking when index out of range

### DIFF
--- a/exec/value.go
+++ b/exec/value.go
@@ -569,6 +569,9 @@ func (v *Value) Len() int {
 // Slice slices an array, slice or string. Otherwise it will
 // return an empty []int.
 func (v *Value) Slice(i, j int) *Value {
+	n := v.Len()
+	i = max(0, min(i, n))
+	j = max(i, min(j, n))
 	switch v.getResolvedValue().Kind() {
 	case reflect.Array, reflect.Slice:
 		return AsValue(v.getResolvedValue().Slice(i, j).Interface())

--- a/tests/integration/lists_test.go
+++ b/tests/integration/lists_test.go
@@ -96,6 +96,27 @@ var _ = Context("lists", func() {
 			})
 		})
 
+		Context("when the list is shorter than the slice bounds", func() {
+			BeforeEach(func() {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{
+					*identifier: heredoc.Doc(`
+					[:10]:  {{ value[:10]  }}
+					[:-5]:  {{ value[:-5]  }}
+					[-10:]: {{ value[-10:] }}
+				`),
+				})
+				(*environment).Context.Set("value", []int{1, 2})
+			})
+
+			It("clamps slices past the bounds rather than panicking", func() {
+				Expect(*returnedErr).To(BeNil())
+				expected := heredoc.Doc(`
+					[:10]:  [1, 2]
+					[:-5]:  []
+					[-10:]: [1, 2]`)
+				AssertPrettyDiff(expected, *returnedResult)
+			})
+		})
 	})
 	Context("when accessing a raw list literal", func() {
 		BeforeEach(func() {

--- a/tests/integration/strings_test.go
+++ b/tests/integration/strings_test.go
@@ -98,6 +98,18 @@ var _ = Context("strings", func() {
 			})
 		})
 
+		Context("when the multi-byte string is shorter than the slice bounds", func() {
+			BeforeEach(func() {
+				*loader = loaders.MustNewMemoryLoader(map[string]string{
+					*identifier: `{{ value[:10] }}`,
+				})
+				(*environment).Context.Set("value", "héllo")
+			})
+			It("clamps to rune count rather than panicking", func() {
+				AssertPrettyDiff("héllo", *returnedResult)
+			})
+		})
+
 		Context("when accessing a raw string literal", func() {
 			BeforeEach(func() {
 				*loader = loaders.MustNewMemoryLoader(map[string]string{


### PR DESCRIPTION
Fixes #90 by clamping the slice index.

PR with assistance from Claude.