### PR TITLE
fix: align attribute filters with Jinja semantics

### DIFF
--- a/builtins/filters.go
+++ b/builtins/filters.go
@@ -912,7 +912,11 @@ func filterRejectAttr(e *exec.Evaluator, in *exec.Value, params *exec.VarArgs) *
 	out := make([]any, 0)
 
 	in.Iterate(func(idx, count int, key, value *exec.Value) bool {
-		attr, _ := resolveAttributeValue(key, attribute, nil)
+		item := key
+		if value != nil {
+			item = value
+		}
+		attr, _ := resolveAttributeValue(item, attribute, nil)
 		keep := false
 		if name == "" {
 			keep = !attr.IsTrue()
@@ -920,7 +924,7 @@ func filterRejectAttr(e *exec.Evaluator, in *exec.Value, params *exec.VarArgs) *
 			keep = !e.ExecuteTestByName(name, attr, testParams).IsTrue()
 		}
 		if keep {
-			out = append(out, key.Interface())
+			out = append(out, item.Interface())
 		}
 		return true
 	}, func() {})
@@ -1617,7 +1621,11 @@ func filterSelectAttr(e *exec.Evaluator, in *exec.Value, params *exec.VarArgs) *
 	out := make([]any, 0)
 
 	in.Iterate(func(idx, count int, key, value *exec.Value) bool {
-		attr, _ := resolveAttributeValue(key, attribute, nil)
+		item := key
+		if value != nil {
+			item = value
+		}
+		attr, _ := resolveAttributeValue(item, attribute, nil)
 		matched := false
 		if name == "" {
 			matched = attr.IsTrue()
@@ -1625,7 +1633,7 @@ func filterSelectAttr(e *exec.Evaluator, in *exec.Value, params *exec.VarArgs) *
 			matched = e.ExecuteTestByName(name, attr, testParams).IsTrue()
 		}
 		if matched {
-			out = append(out, key.Interface())
+			out = append(out, item.Interface())
 		}
 		return true
 	}, func() {})

--- a/tests/integration/filters_collection_compat_test.go
+++ b/tests/integration/filters_collection_compat_test.go
@@ -96,6 +96,29 @@ var _ = Context("collection filter compatibility", func() {
 			want: "Alice|Bob,Cara",
 		},
 		{
+			name:     "selectattr compares regex-looking strings literally",
+			template: `{{ users|selectattr("ip", "equalto", "(ip1|ip2)")|map(attribute="ip")|join(",") }}`,
+			context: map[string]any{
+				"users": []any{
+					map[string]any{"ip": "ip1"},
+					map[string]any{"ip": "(ip1|ip2)"},
+					map[string]any{"ip": "ip2"},
+				},
+			},
+			want: "(ip1|ip2)",
+		},
+		{
+			name:     "selectattr tests values in a dictionary",
+			template: `{{ users|selectattr("ip", "equalto", "(ip1|ip2)")|map(attribute="ip")|join(",") }}`,
+			context: map[string]any{
+				"users": map[string]any{
+					"first":  map[string]any{"ip": "ip1"},
+					"second": map[string]any{"ip": "(ip1|ip2)"},
+				},
+			},
+			want: "(ip1|ip2)",
+		},
+		{
 			name:     "sort supports multiple attributes",
 			template: `{{ users|sort(attribute="meta.rank,name")|map(attribute="name")|join(",") }}`,
 			context: map[string]any{

--- a/tests/integration/macros_test.go
+++ b/tests/integration/macros_test.go
@@ -6,6 +6,12 @@ import (
 )
 
 var _ = Describe("Macro parameters", func() {
+	It("allows a macro to be declared inside another macro", func() {
+		result := renderTemplate(
+			`{% macro outer() %}{% macro inner(value) %}{{ value }}{% endmacro %}{{ inner("ok") }}{% endmacro %}{{ outer() }}`, nil)
+		Expect(result).To(Equal("ok"))
+	})
+
 	Context("*args (varargs)", func() {
 		It("should collect overflow positional args into a list", func() {
 			result := renderTemplate(

--- a/tests/integration/set_test.go
+++ b/tests/integration/set_test.go
@@ -15,10 +15,17 @@ var _ = Describe("{% set %} tag", func() {
 		})
 	})
 
-	Context("expression form (regression)", func() {
+	Context("expression form", func() {
 		It("should still work with a simple assignment", func() {
 			result := renderTemplate(`{% set x = 42 %}{{ x }}`, nil)
 			Expect(result).To(Equal("42"))
+		})
+
+		It("handles an expression split across lines", func() {
+			result := renderTemplate(`{% set values =
+				[1, 2, 3]
+			%}{{ values|join(",") }}`, nil)
+			Expect(result).To(Equal("1,2,3"))
 		})
 	})
 })


### PR DESCRIPTION
Apply selectattr and rejectattr to mapping values and add regressions for multiline set expressions, nested macros, and literal equality.