### PR TITLE
Struct field resolution via a new jinja tag

### DIFF
--- a/exec/value.go
+++ b/exec/value.go
@@ -1056,6 +1056,22 @@ func (v *Value) GetAttribute(name string) (*Value, bool) {
 		if field.IsValid() {
 			return ToValue(field), true
 		}
+
+		typ := val.Type()
+		for i := 0; i < typ.NumField(); i++ {
+			structField := typ.Field(i)
+
+			rawTag, ok := structField.Tag.Lookup("jinja")
+			if !ok {
+				continue
+			}
+
+			if rawTag != name {
+				continue
+			}
+
+			return ToValue(val.Field(i)), true
+		}
 	}
 
 	return AsValue(nil), false // Attr not found

--- a/exec/value_test.go
+++ b/exec/value_test.go
@@ -9,6 +9,25 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type taggedAttributeStructure struct {
+	UserID   string `jinja:"user_id"`
+	JSONName string `json:"json_name"`
+	Hidden   string `jinja:"hidden"`
+}
+
+type taggedMethodPrecedenceStructure struct {
+	MethodValue string `jinja:"Method"`
+}
+
+func (taggedMethodPrecedenceStructure) Method() string {
+	return "method"
+}
+
+type taggedFieldPrecedenceStructure struct {
+	UserID     string `jinja:"alias"`
+	AliasValue string `jinja:"UserID"`
+}
+
 var _ = Context("value", func() {
 	Context("AsValue", func() {
 		var (
@@ -355,6 +374,69 @@ var _ = Context("value", func() {
 				Expect((*returnedAttribute).IsError()).To(BeFalse(), ".isError()")
 				By("returning a nil value")
 				Expect((*returnedAttribute).IsNil()).To(BeTrue(), ".isNil()")
+			})
+		})
+		Context("when the struct field has a jinja tag", func() {
+			BeforeEach(func() {
+				*value = exec.AsValue(taggedAttributeStructure{
+					UserID:   "123456",
+					JSONName: "json value",
+					Hidden:   "hidden value",
+				})
+			})
+			Context("when looked up by its alias", func() {
+				BeforeEach(func() { *attribute = "user_id" })
+				It("should resolve the tagged field", func() {
+					Expect(*returnedOk).To(BeTrue())
+					Expect((*returnedAttribute).String()).To(Equal("123456"))
+				})
+			})
+			Context("when the value is a pointer to the tagged struct", func() {
+				BeforeEach(func() {
+					*value = exec.AsValue(&taggedAttributeStructure{UserID: "123456"})
+					*attribute = "user_id"
+				})
+				It("should resolve the tagged field", func() {
+					Expect(*returnedOk).To(BeTrue())
+					Expect((*returnedAttribute).String()).To(Equal("123456"))
+				})
+			})
+			Context("when the alias is missing", func() {
+				BeforeEach(func() { *attribute = "missing" })
+				It("should return not found", func() {
+					Expect(*returnedOk).To(BeFalse())
+					Expect((*returnedAttribute).IsNil()).To(BeTrue())
+				})
+			})
+			Context("when only a json tag matches", func() {
+				BeforeEach(func() { *attribute = "json_name" })
+				It("should not use the json tag as an alias", func() {
+					Expect(*returnedOk).To(BeFalse())
+					Expect((*returnedAttribute).IsNil()).To(BeTrue())
+				})
+			})
+		})
+		Context("when a method and a tag have the same lookup name", func() {
+			BeforeEach(func() {
+				*value = exec.AsValue(taggedMethodPrecedenceStructure{MethodValue: "tag value"})
+				*attribute = "Method"
+			})
+			It("should prefer the method", func() {
+				Expect(*returnedOk).To(BeTrue())
+				Expect((*returnedAttribute).IsCallable()).To(BeTrue())
+			})
+		})
+		Context("when an exact field name and a tag alias have the same lookup name", func() {
+			BeforeEach(func() {
+				*value = exec.AsValue(taggedFieldPrecedenceStructure{
+					UserID:     "exact field",
+					AliasValue: "tag alias",
+				})
+				*attribute = "UserID"
+			})
+			It("should prefer the exact field name", func() {
+				Expect(*returnedOk).To(BeTrue())
+				Expect((*returnedAttribute).String()).To(Equal("exact field"))
 			})
 		})
 		Context("when the holding value is a map", func() {

--- a/tests/integration/struct_fields_test.go
+++ b/tests/integration/struct_fields_test.go
@@ -1,0 +1,55 @@
+package integration_test
+
+import (
+	"github.com/nikolalohinski/gonja/v2"
+	"github.com/nikolalohinski/gonja/v2/config"
+	"github.com/nikolalohinski/gonja/v2/exec"
+	"github.com/nikolalohinski/gonja/v2/loaders"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type TaggedUser struct {
+	UserID string `jinja:"user_id"`
+}
+
+var _ = Context("struct fields", func() {
+	It("should resolve jinja tags through all shared attribute access paths", func() {
+		template, err := gonja.FromString(`{{ user.UserID }}|{{ user.user_id }}|{{ user["user_id"] }}|{{ user|attr("user_id") }}|{{ [user]|map(attribute="user_id")|first }}`)
+		Expect(err).ToNot(HaveOccurred())
+
+		result, err := template.ExecuteToString(exec.NewContext(map[string]any{
+			"user": TaggedUser{UserID: "123456"},
+		}))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("123456|123456|123456|123456|123456"))
+	})
+
+	It("should preserve missing-field behavior in non-strict mode", func() {
+		template, err := gonja.FromString(`{{ user.missing }}`)
+		Expect(err).ToNot(HaveOccurred())
+
+		result, err := template.ExecuteToString(exec.NewContext(map[string]any{
+			"user": TaggedUser{UserID: "123456"},
+		}))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(""))
+	})
+
+	It("should preserve missing-field behavior in strict mode", func() {
+		configuration := config.New()
+		configuration.StrictUndefined = true
+		loader := loaders.MustNewMemoryLoader(map[string]string{
+			"/test": `{{ user.missing }}`,
+		})
+		template, err := exec.NewTemplate("/test", configuration, loader, gonja.DefaultEnvironment)
+		Expect(err).ToNot(HaveOccurred())
+
+		result, err := template.ExecuteToString(exec.NewContext(map[string]any{
+			"user": TaggedUser{UserID: "123456"},
+		}))
+		Expect(result).To(BeEmpty())
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Issue: https://github.com/NikolaLohinski/gonja/issues/96

This PR adds support for a new "jinja" tag that can be used with structs. This is useful when a jinja template is written with lowercase fields in mind (which is very common for templates as they are often written with python in mind). 

Go struct fields need to have the first character capitalized so that they can be accessible outside the package they were defined in. However most jinja templates expect a lower case field name and this leads to the reported issue. 

Now one could work around this by using lowercase field names. Normally this makes a field "private" outside the package but gonja works around this and can still render the field. However this permissive behavior may not carry to other packages like say encoding/json which can lead to issues if the same struct is used across multiple packages. Again this can also be worked around but this change helps standardize things.

Testing:
The PR adds a few tests.

Also the changes were run against this code:

```go
package main

import (
    "bytes"
    "fmt"

    "github.com/nikolalohinski/gonja/v2"
    "github.com/nikolalohinski/gonja/v2/exec"
)

type User struct {
    UserID string `jinja:"user_id"`
}

func main() {
    user := User{UserID: "123456"}

    for _, template := range []string{
        `{{ user.UserID }}`,
        `{{ user.user_id }}`,
    } {
        tmpl, err := gonja.FromString(template)
        if err != nil {
            panic(err)
        }

        data := exec.NewContext(map[string]interface{}{"user": user})

        var buf bytes.Buffer
        if err := tmpl.Execute(&buf, data); err != nil {
            panic(err)
        }

        fmt.Printf("%s => %q\n", template, buf.String())
    }
}
```

Output:

```
{{ user.UserID }} => "123456"
{{ user.user_id }} => "123456"
```

Full disclosure: This PR is mostly AI generated. But I reviewed the code myself and did some refactoring.